### PR TITLE
add: pallet-gilt storage migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5673,6 +5673,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "parity-scale-codec 3.1.5",
  "scale-info",

--- a/frame/gilt/Cargo.toml
+++ b/frame/gilt/Cargo.toml
@@ -21,6 +21,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 sp-arithmetic = { version = "5.0.0", default-features = false, path = "../../primitives/arithmetic" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
@@ -31,6 +32,7 @@ sp-io = { version = "6.0.0", path = "../../primitives/io" }
 default = ["std"]
 std = [
 	"codec/std",
+	"log/std",
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/frame/gilt/src/migrations/mod.rs
+++ b/frame/gilt/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod v2;

--- a/frame/gilt/src/migrations/v2.rs
+++ b/frame/gilt/src/migrations/v2.rs
@@ -1,0 +1,45 @@
+use crate::*;
+use frame_support::{ 
+    traits::{
+        Get, GetStorageVersion, StorageVersion, PalletInfoAccess, 
+    },
+    weights::Weight, BoundedVec,
+};
+use sp_runtime::traits::Zero;
+use sp_std::vec;
+
+pub fn migrate<T: frame_system::Config + crate::Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
+    let on_chain_storage_version = <P as GetStorageVersion>::on_chain_storage_version();
+	log::info!(
+		target: "runtime::gilt",
+		"Running migration to v2 for gilt with storage version {:?}",
+		on_chain_storage_version,
+	);
+
+    if on_chain_storage_version < 4 {
+        let unbounded = vec![(0, BalanceOf::<T>::zero()); T::QueueCount::get() as usize];
+        let bounded: BoundedVec<_, _> = unbounded
+            .try_into()
+            .expect("QueueTotals should support up to QueueCount items. qed");
+        QueueTotals::<T>::put(bounded);
+		log_migration("migration");
+
+		StorageVersion::new(2).put::<P>();
+		<T as frame_system::Config>::BlockWeights::get().max_block
+	} else {
+		log::warn!(
+			target: "runtime::gilt",
+			"Attempted to apply migration to v2 but failed because storage version is {:?}",
+			on_chain_storage_version,
+		);
+		0
+	}
+}
+
+fn log_migration(stage: &str) {
+	log::info!(
+		target: "runtime::gilt",
+		"{}",
+		stage,
+	);
+}


### PR DESCRIPTION
Add a storage migration for `pallet-gilt` to fix the error when we add it through a runtime upgrade.